### PR TITLE
chore: add basic files

### DIFF
--- a/.github/workflows/run_digest.yaml
+++ b/.github/workflows/run_digest.yaml
@@ -1,0 +1,33 @@
+name: Monthly GitHub Digest
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'  # Runs on the 1st day of each month at 00:00 UTC
+  workflow_dispatch:   # Allows manual triggering
+
+permissions:
+  contents: write
+
+jobs:
+  generate-digest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests
+
+      - name: Run digest script
+        run: |
+          python digest.py
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add github_digest_*.md
+          git commit -m "Add monthly digest for $(date -u +'%Y-%m-%d')" || echo "No changes to commit"
+          git push

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# ecosystem-updates
+# Java Tooling Updates 🚀
+
+Welcome to our monthly digest repository — your go-to source for the latest GitHub activity across some of our cutting-edge projects! 
+
+This digest keeps you informed on new issues, closed issues, and merged pull requests, ensuring you never miss a beat in our evolving ecosystem. 💡📊
+
+### Projects Covered:
+- [bloxbean/cardano-client-lib](https://github.com/bloxbean/cardano-client-lib) 🔗
+- [bloxbean/yaci](https://github.com/bloxbean/yaci) 🔗
+- [bloxbean/yaci-store](https://github.com/bloxbean/yaci-store) 🔗
+- [bloxbean/yaci-devkit](https://github.com/bloxbean/yaci-devkit) 🔗
+
+Please note that all these projects are open source, and everyone is welcome to contribute! 
+🤝 Open collaboration and community contributions drive our progress and innovation.
+
+Stay updated with the latest developments and improvements! Feel free to explore, share, and collaborate! 🎉

--- a/digest.py
+++ b/digest.py
@@ -1,0 +1,104 @@
+import requests
+import datetime
+
+# List of repositories to track
+repos = [
+    "bloxbean/cardano-client-lib",
+    "bloxbean/yaci",
+    "bloxbean/yaci-store",
+    "bloxbean/yaci-devkit"
+]
+
+# GitHub API base URL
+github_api_base = "https://api.github.com/repos/"
+
+# Calculate the start and end dates for the previous calendar month
+now = datetime.datetime.now(datetime.timezone.utc)
+# First day of the current month
+first_day_current_month = datetime.datetime(now.year, now.month, 1)
+# Last day of the previous month is one day before the first day of the current month
+end_date = first_day_current_month - datetime.timedelta(days=1)
+# Start date is the first day of the previous month
+start_date = datetime.datetime(end_date.year, end_date.month, 1)
+
+# GitHub API headers
+headers = {
+    "Accept": "application/vnd.github.v3+json"
+}
+
+# Function to fetch GitHub activity within the previous calendar month
+def fetch_github_activity(repo):
+    # Categories:
+    # - issues_opened: issues created during the previous month
+    # - issues_closed: issues closed during the previous month
+    # - pr_merged: pull requests that were merged (and therefore closed) during the previous month
+    activity = {"issues_opened": [], "issues_closed": [], "pr_merged": []}
+
+    # Fetch PRs and include only those that are merged within the period
+    prs_url = f"{github_api_base}{repo}/pulls?state=all&per_page=100"
+    response = requests.get(prs_url, headers=headers)
+    if response.status_code == 200:
+        prs = response.json()
+        for pr in prs:
+            merged_at = pr.get("merged_at")
+            if merged_at:
+                merged_date = datetime.datetime.strptime(merged_at, "%Y-%m-%dT%H:%M:%SZ")
+                if start_date <= merged_date <= end_date:
+                    pr_link = pr["html_url"]
+                    pr_number = pr["number"]
+                    pr_title = pr["title"]
+                    activity["pr_merged"].append(f"- [#{pr_number} - {pr_title}]({pr_link})")
+
+    # Fetch issues (excluding PRs)
+    issues_url = f"{github_api_base}{repo}/issues?state=all&per_page=100"
+    response = requests.get(issues_url, headers=headers)
+    if response.status_code == 200:
+        issues = response.json()
+        for issue in issues:
+            # Skip items that are actually PRs
+            if "pull_request" in issue:
+                continue
+
+            created_at = datetime.datetime.strptime(issue["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+            closed_at = issue.get("closed_at")
+            issue_link = issue["html_url"]
+            issue_number = issue["number"]
+            issue_title = issue["title"]
+
+            if start_date <= created_at <= end_date:
+                activity["issues_opened"].append(f"- [#{issue_number} - {issue_title}]({issue_link})")
+
+            if closed_at:
+                closed_date = datetime.datetime.strptime(closed_at, "%Y-%m-%dT%H:%M:%SZ")
+                if start_date <= closed_date <= end_date:
+                    activity["issues_closed"].append(f"- [#{issue_number} - {issue_title}]({issue_link})")
+
+    return activity
+
+# Fetch activity for each repository
+repo_activities = {repo: fetch_github_activity(repo) for repo in repos}
+
+# Create digest text
+digest_content = "# Monthly Digest: Java Tooling GitHub Activities\n\n"
+digest_content += f"Period: {start_date.strftime('%Y-%m-%d')} to {end_date.strftime('%Y-%m-%d')}\n\n"
+
+for repo, activity in repo_activities.items():
+    repo_link = f"https://github.com/{repo}"
+    digest_content += f"## [{repo}]({repo_link})\n\n"
+
+    if activity["issues_opened"]:
+        digest_content += "**Issues open:**\n" + "\n".join(activity["issues_opened"]) + "\n\n"
+    if activity["pr_merged"]:
+        digest_content += "**PRs merged & closed:**\n" + "\n".join(activity["pr_merged"]) + "\n\n"
+    if activity["issues_closed"]:
+        digest_content += "**Issues closed:**\n" + "\n".join(activity["issues_closed"]) + "\n\n"
+
+    if not (activity["issues_opened"] or activity["pr_merged"] or activity["issues_closed"]):
+        digest_content += "_No significant activity in this period._\n\n"
+
+# Generate file name with month and year (e.g., github_digest_February_2025.md)
+filename = f"github_digest_{end_date.strftime('%B_%Y')}.md"
+with open(filename, "w") as file:
+    file.write(digest_content)
+
+print(f"Monthly digest saved to {filename}")


### PR DESCRIPTION
This PR contain 2 main files:

digest.py
- Sets up a list of repositories and GitHub API parameters.
- Calculates the start and end dates for the previous calendar month.
- Fetches merged pull requests, opened issues, and closed issues via GitHub API.
- Compiles this activity into a markdown-formatted digest by repository.
- Saves the digest to a file named with the corresponding month and year.

run_digest.yaml
- Defines a GitHub Action workflow that runs on the 1st of each month at 00:00 UTC or can be triggered manually.
- Grants write permission to repository contents.
- Checks out the repository and sets up a Python environment on an Ubuntu runner.
- Installs required Python dependencies (i.e., requests).
- Configures git, stages any updated markdown digest files, commits them with a timestamp, and pushes the changes.
